### PR TITLE
refactor(srv): rename handler service method names

### DIFF
--- a/internal/service/balance.go
+++ b/internal/service/balance.go
@@ -11,8 +11,8 @@ import (
 	"github.com/google/uuid"
 )
 
-func (h handlerService) HandleEventBalanceCreated(ctx context.Context, msg botMessage) error {
-	logger := h.logger.With().Str("name", "handlerService.HandleEventBalanceCreated").Logger()
+func (h handlerService) HandleBalanceCreate(ctx context.Context, msg botMessage) error {
+	logger := h.logger.With().Str("name", "handlerService.HandleBalanceCreate").Logger()
 
 	var nextStep models.FlowStep
 	stateMetaData := ctx.Value(contextFieldNameState).(*models.State).Metedata
@@ -177,8 +177,8 @@ func (h *handlerService) handleCreateBalanceFlowStep(ctx context.Context, opts h
 	return nil
 }
 
-func (h handlerService) HandleEventBalanceUpdated(ctx context.Context, msg botMessage) error {
-	logger := h.logger.With().Str("name", "handlerService.HandleEventBalanceUpdated").Logger()
+func (h handlerService) HandleBalanceUpdate(ctx context.Context, msg botMessage) error {
+	logger := h.logger.With().Str("name", "handlerService.HandleBalanceUpdate").Logger()
 
 	var nextStep models.FlowStep
 	stateMetaData := ctx.Value(contextFieldNameState).(*models.State).Metedata
@@ -416,8 +416,8 @@ func (h handlerService) updateBalance(ctx context.Context, opts updateBalanceOpt
 	return balance, nil
 }
 
-func (h handlerService) HandleEventGetBalance(ctx context.Context, msg botMessage) error {
-	logger := h.logger.With().Str("name", "handlerService.HandleEventGetBalance").Logger()
+func (h handlerService) HandleBalanceGet(ctx context.Context, msg botMessage) error {
+	logger := h.logger.With().Str("name", "handlerService.HandleBalanceGet").Logger()
 
 	var nextStep models.FlowStep
 	defer func() {
@@ -512,8 +512,8 @@ func (h handlerService) processGetBalanceInfo(ctx context.Context, msg botMessag
 	return nil
 }
 
-func (h handlerService) HandleEventBalanceDeleted(ctx context.Context, msg botMessage) error {
-	logger := h.logger.With().Str("name", "handlerService.HandleEventBalanceDeleted").Logger()
+func (h handlerService) HandleBalanceDelete(ctx context.Context, msg botMessage) error {
+	logger := h.logger.With().Str("name", "handlerService.HandleBalanceDelete").Logger()
 
 	var nextStep models.FlowStep
 	stateMetaData := ctx.Value(contextFieldNameState).(*models.State).Metedata

--- a/internal/service/category.go
+++ b/internal/service/category.go
@@ -10,8 +10,8 @@ import (
 	"github.com/google/uuid"
 )
 
-func (h handlerService) HandleEventCategoryCreated(ctx context.Context, msg botMessage) error {
-	logger := h.logger.With().Str("name", "handlerService.HandleEventCategoryCreated").Logger()
+func (h handlerService) HandleCategoryCreate(ctx context.Context, msg botMessage) error {
+	logger := h.logger.With().Str("name", "handlerService.HandleCategoryCreate").Logger()
 
 	var nextStep models.FlowStep
 	defer func() {
@@ -122,8 +122,8 @@ func (h handlerService) handleEnterCategoryNameFlowStep(ctx context.Context, opt
 	return nil
 }
 
-func (h handlerService) HandleEventListCategories(ctx context.Context, msg botMessage) error {
-	logger := h.logger.With().Str("name", "handlerService.HandleEventListCategories").Logger()
+func (h handlerService) HandleCategoryList(ctx context.Context, msg botMessage) error {
+	logger := h.logger.With().Str("name", "handlerService.HandleCategoryList").Logger()
 
 	var nextStep models.FlowStep
 	defer func() {
@@ -227,8 +227,8 @@ func (h handlerService) handleListCategoriesFlowStep(ctx context.Context, opts h
 	return nil
 }
 
-func (h handlerService) HandleEventCategoryUpdated(ctx context.Context, msg botMessage) error {
-	logger := h.logger.With().Str("name", "handlerService.HandleEventCategoryUpdated").Logger()
+func (h handlerService) HandleCategoryUpdate(ctx context.Context, msg botMessage) error {
+	logger := h.logger.With().Str("name", "handlerService.HandleCategoryUpdate").Logger()
 	logger.Debug().Any("msg", msg).Msg("got args")
 
 	var nextStep models.FlowStep
@@ -370,8 +370,8 @@ func (h handlerService) handleEnterUpdatedCategoryNameFlowStep(ctx context.Conte
 	return nil
 }
 
-func (h handlerService) HandleEventCategoryDeleted(ctx context.Context, msg botMessage) error {
-	logger := h.logger.With().Str("name", "handlerService.HandleEventCategoryDeleted").Logger()
+func (h handlerService) HandleCategoryDelete(ctx context.Context, msg botMessage) error {
+	logger := h.logger.With().Str("name", "handlerService.HandleCategoryDelete").Logger()
 
 	var nextStep models.FlowStep
 	defer func() {

--- a/internal/service/event.go
+++ b/internal/service/event.go
@@ -113,7 +113,7 @@ func (e eventService) ReactOnEvent(ctx context.Context, event models.Event, msg 
 
 	switch event {
 	case models.StartEvent:
-		err := e.handlerService.HandleEventStart(ctx, msg)
+		err := e.handlerService.HandleStart(ctx, msg)
 		if err != nil {
 			if errs.IsExpected(err) {
 				logger.Info().Err(err).Msg(err.Error())
@@ -125,7 +125,7 @@ func (e eventService) ReactOnEvent(ctx context.Context, event models.Event, msg 
 		}
 
 	case models.UnknownEvent:
-		err := e.handlerService.HandleEventUnknown(msg)
+		err := e.handlerService.HandleUnknown(msg)
 		if err != nil {
 			if errs.IsExpected(err) {
 				logger.Info().Err(err).Msg(err.Error())
@@ -137,7 +137,7 @@ func (e eventService) ReactOnEvent(ctx context.Context, event models.Event, msg 
 		}
 
 	case models.BackEvent:
-		err := e.handlerService.HandleEventBack(ctx, msg)
+		err := e.handlerService.HandleBack(ctx, msg)
 		if err != nil {
 			logger.Error().Err(err).Msg("handle event back")
 			return fmt.Errorf("handle event back: %w", err)
@@ -151,7 +151,7 @@ func (e eventService) ReactOnEvent(ctx context.Context, event models.Event, msg 
 		}
 
 	case models.CreateBalanceEvent:
-		err := e.handlerService.HandleEventBalanceCreated(ctx, msg)
+		err := e.handlerService.HandleBalanceCreate(ctx, msg)
 		if err != nil {
 			if errs.IsExpected(err) {
 				logger.Info().Err(err).Msg(err.Error())
@@ -163,7 +163,7 @@ func (e eventService) ReactOnEvent(ctx context.Context, event models.Event, msg 
 		}
 
 	case models.UpdateBalanceEvent:
-		err := e.handlerService.HandleEventBalanceUpdated(ctx, msg)
+		err := e.handlerService.HandleBalanceUpdate(ctx, msg)
 		if err != nil {
 			if errs.IsExpected(err) {
 				logger.Info().Err(err).Msg(err.Error())
@@ -175,7 +175,7 @@ func (e eventService) ReactOnEvent(ctx context.Context, event models.Event, msg 
 		}
 
 	case models.GetBalanceEvent:
-		err := e.handlerService.HandleEventGetBalance(ctx, msg)
+		err := e.handlerService.HandleBalanceGet(ctx, msg)
 		if err != nil {
 			if errs.IsExpected(err) {
 				logger.Info().Err(err).Msg(err.Error())
@@ -187,7 +187,7 @@ func (e eventService) ReactOnEvent(ctx context.Context, event models.Event, msg 
 		}
 
 	case models.DeleteBalanceEvent:
-		err := e.handlerService.HandleEventBalanceDeleted(ctx, msg)
+		err := e.handlerService.HandleBalanceDelete(ctx, msg)
 		if err != nil {
 			if errs.IsExpected(err) {
 				logger.Info().Err(err).Msg(err.Error())
@@ -199,7 +199,7 @@ func (e eventService) ReactOnEvent(ctx context.Context, event models.Event, msg 
 		}
 
 	case models.CreateCategoryEvent:
-		err := e.handlerService.HandleEventCategoryCreated(ctx, msg)
+		err := e.handlerService.HandleCategoryCreate(ctx, msg)
 		if err != nil {
 			if errs.IsExpected(err) {
 				logger.Info().Err(err).Msg(err.Error())
@@ -211,7 +211,7 @@ func (e eventService) ReactOnEvent(ctx context.Context, event models.Event, msg 
 		}
 
 	case models.ListCategoriesEvent:
-		err := e.handlerService.HandleEventListCategories(ctx, msg)
+		err := e.handlerService.HandleCategoryList(ctx, msg)
 		if err != nil {
 			if errs.IsExpected(err) {
 				logger.Info().Err(err).Msg(err.Error())
@@ -223,7 +223,7 @@ func (e eventService) ReactOnEvent(ctx context.Context, event models.Event, msg 
 		}
 
 	case models.UpdateCategoryEvent:
-		err := e.handlerService.HandleEventCategoryUpdated(ctx, msg)
+		err := e.handlerService.HandleCategoryUpdate(ctx, msg)
 		if err != nil {
 			if errs.IsExpected(err) {
 				logger.Info().Err(err).Msg(err.Error())
@@ -234,7 +234,7 @@ func (e eventService) ReactOnEvent(ctx context.Context, event models.Event, msg 
 		}
 
 	case models.DeleteCategoryEvent:
-		err := e.handlerService.HandleEventCategoryDeleted(ctx, msg)
+		err := e.handlerService.HandleCategoryDelete(ctx, msg)
 		if err != nil {
 			if errs.IsExpected(err) {
 				logger.Info().Err(err).Msg(err.Error())
@@ -245,7 +245,7 @@ func (e eventService) ReactOnEvent(ctx context.Context, event models.Event, msg 
 		}
 
 	case models.CreateOperationEvent:
-		err := e.handlerService.HandleEventOperationCreated(ctx, msg)
+		err := e.handlerService.HandleOperationCreate(ctx, msg)
 		if err != nil {
 			if errs.IsExpected(err) {
 				logger.Info().Err(err).Msg(err.Error())
@@ -257,7 +257,7 @@ func (e eventService) ReactOnEvent(ctx context.Context, event models.Event, msg 
 		}
 
 	case models.GetOperationsHistoryEvent:
-		err := e.handlerService.HandleEventGetOperationsHistory(ctx, msg)
+		err := e.handlerService.HandleOperationHistory(ctx, msg)
 		if err != nil {
 			if errs.IsExpected(err) {
 				logger.Info().Err(err).Msg(err.Error())

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -35,8 +35,8 @@ func NewHandler(opts *HandlerOptions) *handlerService {
 	}
 }
 
-func (h handlerService) HandleEventStart(ctx context.Context, msg botMessage) error {
-	logger := h.logger.With().Str("name", "handlerService.HandleEventStart").Logger()
+func (h handlerService) HandleStart(ctx context.Context, msg botMessage) error {
+	logger := h.logger.With().Str("name", "handlerService.HandleStart").Logger()
 
 	var nextStep models.FlowStep
 	defer func() {
@@ -106,8 +106,8 @@ func (h handlerService) HandleEventStart(ctx context.Context, msg botMessage) er
 	return nil
 }
 
-func (h handlerService) HandleEventBack(ctx context.Context, msg botMessage) error {
-	logger := h.logger.With().Str("name", "handlerService.HandleEventBack").Logger()
+func (h handlerService) HandleBack(ctx context.Context, msg botMessage) error {
+	logger := h.logger.With().Str("name", "handlerService.HandleBack").Logger()
 
 	err := h.services.Keyboard.CreateKeyboard(&CreateKeyboardOptions{
 		ChatID:  msg.Message.Chat.ID,
@@ -123,8 +123,8 @@ func (h handlerService) HandleEventBack(ctx context.Context, msg botMessage) err
 	return nil
 }
 
-func (h handlerService) HandleEventUnknown(msg botMessage) error {
-	logger := h.logger.With().Str("name", "handlerService.HandleEventUnknown").Logger()
+func (h handlerService) HandleUnknown(msg botMessage) error {
+	logger := h.logger.With().Str("name", "handlerService.HandleUnknown").Logger()
 
 	err := h.services.Message.SendMessage(&SendMessageOptions{
 		ChatID: msg.Message.Chat.ID,

--- a/internal/service/operation.go
+++ b/internal/service/operation.go
@@ -13,8 +13,8 @@ import (
 	"github.com/google/uuid"
 )
 
-func (h handlerService) HandleEventOperationCreated(ctx context.Context, msg botMessage) error {
-	logger := h.logger.With().Str("name", "handlerService.HandleEventOperationCreated").Logger()
+func (h handlerService) HandleOperationCreate(ctx context.Context, msg botMessage) error {
+	logger := h.logger.With().Str("name", "handlerService.HandleOperationCreate").Logger()
 
 	var nextStep models.FlowStep
 	stateMetaData := ctx.Value(contextFieldNameState).(*models.State).Metedata
@@ -550,8 +550,8 @@ func (h handlerService) processTransferOperation(ctx context.Context, opts proce
 	return nil
 }
 
-func (h handlerService) HandleEventGetOperationsHistory(ctx context.Context, msg botMessage) error {
-	logger := h.logger.With().Str("name", "handlerService.HandleEventGetOperationsHistory").Logger()
+func (h handlerService) HandleOperationHistory(ctx context.Context, msg botMessage) error {
+	logger := h.logger.With().Str("name", "handlerService.HandleOperationHistory").Logger()
 
 	var nextStep models.FlowStep
 	stateMetaData := ctx.Value(contextFieldNameState).(*models.State).Metedata

--- a/internal/service/services.go
+++ b/internal/service/services.go
@@ -17,42 +17,43 @@ type Services struct {
 	State    StateService
 }
 
-// HandlerService provides functionally for handling events.
+// HandlerService provides functionally for handling bot events.
 type HandlerService interface {
-	// HandleError is used to send the user a message that something went wrong while processing the command.
+	// HandleError is used to send the user a message that something went wrong while processing the event.
 	HandleError(ctx context.Context, err error, msg botMessage) error
-	// HandleEventUnknown is used to handle event unknown.
-	HandleEventUnknown(msg botMessage) error
-	// HandleEventStart is used to handle event start.
-	HandleEventStart(ctx context.Context, msg botMessage) error
-	// HandleEventBack is used to reset bot buttons to default mode.
-	HandleEventBack(ctx context.Context, msg botMessage) error
+	// HandleUnknown inform user that provided event is unknown and notify him about available events.
+	HandleUnknown(msg botMessage) error
 
-	// HandleWrappers is used to handle wrapper events.
+	// HandleStart initialize new user, his balance and send welcome message.
+	HandleStart(ctx context.Context, msg botMessage) error
+	// HandleBack resets user interface to main menu.
+	HandleBack(ctx context.Context, msg botMessage) error
+	// HandleWrappers processes main keyboard selections, where each button (Balance/Operations/Categories)
+	// maps to corresponding model wrapper to handle its specific actions.
 	HandleWrappers(ctx context.Context, event models.Event, msg botMessage) error
 
-	// HandleEventBalanceCreated is used to handle update balance event.
-	HandleEventBalanceCreated(ctx context.Context, msg botMessage) error
-	// HandleEventBalanceUpdated is used to handle update balance event.
-	HandleEventBalanceUpdated(ctx context.Context, msg botMessage) error
-	// HandleEventGetBalance is used to handle get balance event.
-	HandleEventGetBalance(ctx context.Context, msg botMessage) error
-	// HandleEventBalanceDeleted is used to handle delete balance event.
-	HandleEventBalanceDeleted(ctx context.Context, msg botMessage) error
+	// HandleBalanceCreate processes new balance entry creation
+	HandleBalanceCreate(ctx context.Context, msg botMessage) error
+	// HandleBalanceUpdate processes balance modification
+	HandleBalanceUpdate(ctx context.Context, msg botMessage) error
+	// HandleBalanceGet retrieves current balance information
+	HandleBalanceGet(ctx context.Context, msg botMessage) error
+	// HandleBalanceDelete processes balance entry removal
+	HandleBalanceDelete(ctx context.Context, msg botMessage) error
 
-	// HandleEventCategoryCreate is used to handle category created event.
-	HandleEventCategoryCreated(ctx context.Context, msg botMessage) error
-	// HandleEventListCategories is used to handle lit categories event.
-	HandleEventListCategories(ctx context.Context, msg botMessage) error
-	// HandleEventCategoryUpdated is used to handle update category event.
-	HandleEventCategoryUpdated(ctx context.Context, msg botMessage) error
-	// HandleEventCategoryDeleted is used to handle delete category event.
-	HandleEventCategoryDeleted(ctx context.Context, msg botMessage) error
+	// HandleCategoryCreate processes new category creation
+	HandleCategoryCreate(ctx context.Context, msg botMessage) error
+	// HandleCategoryList retrieves all available categories
+	HandleCategoryList(ctx context.Context, msg botMessage) error
+	// HandleCategoryUpdate processes category modification
+	HandleCategoryUpdate(ctx context.Context, msg botMessage) error
+	// HandleCategoryDelete processes category removal
+	HandleCategoryDelete(ctx context.Context, msg botMessage) error
 
-	// HandleEventOperationCreated is used to create an operation.
-	HandleEventOperationCreated(ctc context.Context, msg botMessage) error
-	// HandleEventGetOperationsHistory is used to get operations history.
-	HandleEventGetOperationsHistory(ctx context.Context, msg botMessage) error
+	// HandleOperationCreate processes new operation creation
+	HandleOperationCreate(ctx context.Context, msg botMessage) error
+	// HandleOperationHistory retrieves operation transaction history
+	HandleOperationHistory(ctx context.Context, msg botMessage) error
 }
 
 // EventService provides functionally for receiving an updates from bot and reacting on it.


### PR DESCRIPTION
### What does this PR do and why?

In this PR I've changed the names and comments for `HandlerService` to make them more understandable.