### PR TITLE
fix: panic with nil state and error handling

### DIFF
--- a/internal/service/event.go
+++ b/internal/service/event.go
@@ -179,6 +179,10 @@ func (e eventService) ReactOnEvent(ctx context.Context, event models.Event, msg 
 		models.CreateOperationEvent, models.GetOperationsHistoryEvent, models.DeleteOperationEvent:
 		err := e.services.Handler.HandleAction(ctx, msg)
 		if err != nil {
+			if errs.IsExpected(err) {
+				logger.Info().Err(err).Msg(err.Error())
+				return err
+			}
 			logger.Error().Err(err).Msg("handle action")
 			return fmt.Errorf("handle action: %w", err)
 		}


### PR DESCRIPTION
### What does this PR do and why?

In this PR I've fixed 2 URGENT issues:
1. Handling of custom errors that are coming from `handlerService.HandleAction` method.
2. Panic when we return `nil` state.