### PR TITLE
fix(operation/create): do not show transfer type if user has only one balance

### DIFF
--- a/internal/service/operation.go
+++ b/internal/service/operation.go
@@ -40,7 +40,6 @@ func (h handlerService) handleCreateOperationFlowStep(ctx context.Context, opts 
 		chooseOperationTypeKeyboard[0].Buttons = append(chooseOperationTypeKeyboard[0].Buttons, InlineKeyboardButton{
 			Text: models.BotCreateTransferOperationCommand,
 		})
-
 	}
 
 	return models.ProcessOperationTypeFlowStep, h.apis.Messenger.SendWithKeyboard(SendWithKeyboardOptions{


### PR DESCRIPTION
### What does this PR do and why?
The initial problem described here: #43 

I decided to not show the transfer operation type during create operation flow if user has only one balance.


closes #43 