### PR TITLE
feat: store currencies and their symbol on our side

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -52,6 +52,8 @@ func Run(ctx context.Context, cfg *config.Config, logger *logger.Logger) {
 		Currency:  store.NewCurrency(mongoDB),
 	}
 
+	currencyService := service.NewCurrency(logger, apis, stores)
+
 	stateService := service.NewState(&service.StateOptions{
 		Logger: logger,
 		Stores: stores,
@@ -59,7 +61,8 @@ func Run(ctx context.Context, cfg *config.Config, logger *logger.Logger) {
 	})
 
 	services := service.Services{
-		State: stateService,
+		State:    stateService,
+		Currency: currencyService,
 	}
 
 	handlerService := service.NewHandler(&service.HandlerOptions{
@@ -76,6 +79,11 @@ func Run(ctx context.Context, cfg *config.Config, logger *logger.Logger) {
 		APIs:     apis,
 		Services: services,
 	})
+
+	err = currencyService.InitCurrencies(ctx)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("init currencies")
+	}
 
 	go eventService.Listen(ctx)
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -49,6 +49,7 @@ func Run(ctx context.Context, cfg *config.Config, logger *logger.Logger) {
 		Balance:   store.NewBalance(mongoDB),
 		Operation: store.NewOperation(mongoDB),
 		State:     store.NewState(mongoDB),
+		Currency:  store.NewCurrency(mongoDB),
 	}
 
 	stateService := service.NewState(&service.StateOptions{

--- a/internal/models/currency.go
+++ b/internal/models/currency.go
@@ -1,6 +1,6 @@
 package models
 
-// Currency represents currency
+// Currency represents currency model which contains currency name, code and symbol
 type Currency struct {
 	ID     string `bson:"_id"`
 	Name   string `bson:"name"`

--- a/internal/models/currency.go
+++ b/internal/models/currency.go
@@ -1,0 +1,9 @@
+package models
+
+// Currency represents currency
+type Currency struct {
+	ID     string `bson:"_id"`
+	Name   string `bson:"name"`
+	Code   string `bson:"code"`
+	Symbol string `bson:"symbol"`
+}

--- a/internal/service/currency.go
+++ b/internal/service/currency.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/VladPetriv/finance_bot/internal/models"
+	"github.com/VladPetriv/finance_bot/pkg/errs"
+	"github.com/VladPetriv/finance_bot/pkg/logger"
+	"github.com/VladPetriv/finance_bot/pkg/money"
+	"github.com/google/uuid"
+)
+
+type currencyService struct {
+	logger   *logger.Logger
+	storages Stores
+	apis     APIs
+}
+
+// NewCurrency returns new instance of currency service.
+func NewCurrency(logger *logger.Logger, apis APIs, storages Stores) *currencyService {
+	return &currencyService{
+		logger:   logger,
+		apis:     apis,
+		storages: storages,
+	}
+}
+
+// availableCurrenciesCount represents the number of available currencies which can be received from the CurrencyExchanger API.
+const availableCurrenciesCount = 161
+
+func (c *currencyService) InitCurrencies(ctx context.Context) error {
+	logger := c.logger.With().Str("name", "currencyService.InitCurrencies").Logger()
+	logger.Debug().Msg("got args")
+
+	currenciesCount, err := c.storages.Currency.Count(ctx)
+	if err != nil {
+		logger.Error().Err(err).Msg("count currencies in the database")
+		return fmt.Errorf("count currencies in the database: %w", err)
+	}
+	if currenciesCount == availableCurrenciesCount {
+		logger.Info().Any("currenciesCount", currenciesCount).Msg("currencies already initialized")
+		return nil
+	}
+
+	currencies, err := c.apis.CurrencyExchanger.FetchCurrencies()
+	if err != nil {
+		logger.Error().Err(err).Msg("fetch currencies through currency exchanger")
+		return fmt.Errorf("fetch currencies through currency exchanger: %w", err)
+	}
+	if len(currencies) == 0 {
+		logger.Info().Msg("currencies not found")
+		return nil
+	}
+
+	for _, currency := range currencies {
+		err := c.storages.Currency.Create(ctx, &models.Currency{
+			ID:     uuid.NewString(),
+			Name:   currency.Name,
+			Code:   currency.Code,
+			Symbol: currency.Symbol,
+		})
+		if err != nil {
+			logger.Error().Err(err).Any("currency", currency).Msg("create currency in the database")
+
+			continue
+		}
+	}
+
+	return nil
+}
+
+func (c *currencyService) Convert(ctx context.Context, opts ConvertCurrencyOptions) (*money.Money, error) {
+	logger := c.logger.With().Str("name", "currencyService.Convert").Logger()
+	logger.Debug().Any("opts", opts).Msg("got args")
+
+	exchangeRate, err := c.apis.CurrencyExchanger.GetExchangeRate(opts.BaseCurrency, opts.TargetCurrency)
+	if err != nil {
+		if errs.IsExpected(err) {
+			logger.Info().Msg(err.Error())
+			return nil, err
+		}
+
+		logger.Error().Err(err).Msg("get exchange rate through currency exchanger")
+		return nil, fmt.Errorf("get exchange rate through currency exchanger: %w", err)
+	}
+	logger.Debug().Any("exchangeRate", exchangeRate).Msg("got exchange rate")
+
+	opts.Amount.Mul(*exchangeRate)
+
+	return &opts.Amount, nil
+}

--- a/internal/service/currency.go
+++ b/internal/service/currency.go
@@ -54,7 +54,7 @@ func (c *currencyService) InitCurrencies(ctx context.Context) error {
 	}
 
 	for _, currency := range currencies {
-		err := c.storages.Currency.Create(ctx, &models.Currency{
+		err := c.storages.Currency.CreateIfNotExists(ctx, &models.Currency{
 			ID:     uuid.NewString(),
 			Name:   currency.Name,
 			Code:   currency.Code,

--- a/internal/service/services.go
+++ b/internal/service/services.go
@@ -239,6 +239,7 @@ type CurrencyService interface {
 	Convert(ctx context.Context, opts ConvertCurrencyOptions) (*money.Money, error)
 }
 
+// ConvertCurrencyOptions represents options for converting currency.
 type ConvertCurrencyOptions struct {
 	BaseCurrency   string
 	TargetCurrency string

--- a/internal/service/services.go
+++ b/internal/service/services.go
@@ -5,13 +5,15 @@ import (
 
 	"github.com/VladPetriv/finance_bot/internal/models"
 	"github.com/VladPetriv/finance_bot/pkg/errs"
+	"github.com/VladPetriv/finance_bot/pkg/money"
 )
 
 // Services represents structure with all services.
 type Services struct {
-	Event   EventService
-	Handler HandlerService
-	State   StateService
+	Event    EventService
+	Handler  HandlerService
+	State    StateService
+	Currency CurrencyService
 }
 
 // HandlerService provides functionally for handling bot events.
@@ -227,4 +229,18 @@ type StateService interface {
 type HandleStateOutput struct {
 	State *models.State
 	Event models.Event
+}
+
+// CurrencyService represents a service for managing and handling currencies.
+type CurrencyService interface {
+	// InitCurrencies is used to initialize currencies by parsing them from the CurrencyExchanger API and saving them to the database.
+	InitCurrencies(ctx context.Context) error
+	// Convert is used to convert operations amount from base currency to target currency
+	Convert(ctx context.Context, opts ConvertCurrencyOptions) (*money.Money, error)
+}
+
+type ConvertCurrencyOptions struct {
+	BaseCurrency   string
+	TargetCurrency string
+	Amount         money.Money
 }

--- a/internal/service/stores.go
+++ b/internal/service/stores.go
@@ -138,7 +138,7 @@ type GetStateFilter struct {
 
 // CurrencyStore represents a store for currencies.
 type CurrencyStore interface {
-	// Create creates a new currency in store.
+	// Create creates a new currency in store(only in case if currency not exists).
 	Create(ctx context.Context, currency *models.Currency) error
 	// Count returns a count of all currencies from store.
 	Count(ctx context.Context) (int, error)

--- a/internal/service/stores.go
+++ b/internal/service/stores.go
@@ -14,6 +14,7 @@ type Stores struct {
 	Category  CategoryStore
 	User      UserStore
 	State     StateStore
+	Currency  CurrencyStore
 }
 
 // UserStore provides functionality for work with users store.
@@ -133,4 +134,14 @@ type StateStore interface {
 // GetStateFilter represents a filters for StateStore.Get method.
 type GetStateFilter struct {
 	UserID string
+}
+
+// CurrencyStore represents a store for currencies.
+type CurrencyStore interface {
+	// Create creates a new currency in store.
+	Create(ctx context.Context, currency *models.Currency) error
+	// Count returns a count of all currencies from store.
+	Count(ctx context.Context) (int, error)
+	// List returns a list of all currencies from store.
+	List(ctx context.Context) ([]models.Currency, error)
 }

--- a/internal/service/stores.go
+++ b/internal/service/stores.go
@@ -139,6 +139,7 @@ type GetStateFilter struct {
 // CurrencyStore represents a store for currencies.
 type CurrencyStore interface {
 	// Create creates a new currency in store(only in case if currency not exists).
+	// The check for existence is based on currency code(models.Currency.Code).
 	CreateIfNotExists(ctx context.Context, currency *models.Currency) error
 	// Count returns a count of all currencies from store.
 	Count(ctx context.Context) (int, error)

--- a/internal/service/stores.go
+++ b/internal/service/stores.go
@@ -139,7 +139,7 @@ type GetStateFilter struct {
 // CurrencyStore represents a store for currencies.
 type CurrencyStore interface {
 	// Create creates a new currency in store(only in case if currency not exists).
-	Create(ctx context.Context, currency *models.Currency) error
+	CreateIfNotExists(ctx context.Context, currency *models.Currency) error
 	// Count returns a count of all currencies from store.
 	Count(ctx context.Context) (int, error)
 	// List returns a list of all currencies from store.

--- a/internal/store/currency.go
+++ b/internal/store/currency.go
@@ -1,0 +1,60 @@
+package store
+
+import (
+	"context"
+
+	"github.com/VladPetriv/finance_bot/internal/models"
+	"github.com/VladPetriv/finance_bot/pkg/database"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+type currencyStore struct {
+	*database.MongoDB
+}
+
+var collectionCurrency = "Currencies"
+
+// NewCurrency creates a new currency store.
+func NewCurrency(db *database.MongoDB) *currencyStore {
+	return &currencyStore{
+		db,
+	}
+}
+
+func (c *currencyStore) Create(ctx context.Context, currency *models.Currency) error {
+	_, err := c.DB.Collection(collectionCurrency).InsertOne(ctx, currency)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *currencyStore) Count(ctx context.Context) (int, error) {
+	count, err := c.DB.Collection(collectionCurrency).CountDocuments(ctx, bson.M{})
+	if err != nil {
+		return 0, err
+	}
+
+	return int(count), nil
+}
+
+func (c *currencyStore) List(ctx context.Context) ([]models.Currency, error) {
+	cursor, err := c.DB.Collection(collectionCurrency).Find(ctx, bson.M{})
+	if err != nil {
+		return nil, err
+	}
+
+	var currencies []models.Currency
+	err = cursor.All(ctx, &currencies)
+	if err != nil {
+		return nil, err
+	}
+
+	err = cursor.Close(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return currencies, nil
+}

--- a/internal/store/currency.go
+++ b/internal/store/currency.go
@@ -6,6 +6,7 @@ import (
 	"github.com/VladPetriv/finance_bot/internal/models"
 	"github.com/VladPetriv/finance_bot/pkg/database"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 type currencyStore struct {
@@ -22,12 +23,14 @@ func NewCurrency(db *database.MongoDB) *currencyStore {
 }
 
 func (c *currencyStore) Create(ctx context.Context, currency *models.Currency) error {
-	_, err := c.DB.Collection(collectionCurrency).InsertOne(ctx, currency)
-	if err != nil {
-		return err
+	opts := options.Update().SetUpsert(true)
+	filter := bson.M{"code": currency.Code}
+	update := bson.M{
+		"$setOnInsert": currency,
 	}
 
-	return nil
+	_, err := c.DB.Collection(collectionCurrency).UpdateOne(ctx, filter, update, opts)
+	return err
 }
 
 func (c *currencyStore) Count(ctx context.Context) (int, error) {

--- a/internal/store/currency.go
+++ b/internal/store/currency.go
@@ -22,7 +22,7 @@ func NewCurrency(db *database.MongoDB) *currencyStore {
 	}
 }
 
-func (c *currencyStore) Create(ctx context.Context, currency *models.Currency) error {
+func (c *currencyStore) CreateIfNotExists(ctx context.Context, currency *models.Currency) error {
 	opts := options.Update().SetUpsert(true)
 	filter := bson.M{"code": currency.Code}
 	update := bson.M{

--- a/internal/store/currency_test.go
+++ b/internal/store/currency_test.go
@@ -1,0 +1,231 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/VladPetriv/finance_bot/config"
+	"github.com/VladPetriv/finance_bot/internal/models"
+	"github.com/VladPetriv/finance_bot/internal/store"
+	"github.com/VladPetriv/finance_bot/pkg/database"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestCurrency_Create(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background() //nolint: forbidigo
+	cfg := config.Get()
+
+	db, err := database.NewMongoDB(ctx, cfg.MongoDB.URI, cfg.MongoDB.Database)
+	require.NoError(t, err)
+	currencyStore := store.NewCurrency(db)
+
+	currencyID := uuid.NewString()
+
+	testCases := []struct {
+		desc                 string
+		preconditions        *models.Currency
+		input                *models.Currency
+		expectDuplicateError bool
+	}{
+		{
+			desc: "positive: currency created",
+			input: &models.Currency{
+				ID:     uuid.NewString(),
+				Name:   "US Dollar",
+				Symbol: "$",
+			},
+		},
+		{
+			desc: "negative: currency not created because already exists",
+			preconditions: &models.Currency{
+				ID:     currencyID,
+				Name:   "Euro",
+				Symbol: "€",
+			},
+			input: &models.Currency{
+				ID:     currencyID,
+				Name:   "Euro",
+				Symbol: "€",
+			},
+			expectDuplicateError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.preconditions != nil {
+				err = currencyStore.Create(ctx, tc.preconditions)
+				assert.NoError(t, err)
+			}
+
+			t.Cleanup(func() {
+				_, err := currencyStore.DB.Collection("Currencies").DeleteOne(ctx, bson.M{"_id": tc.input.ID})
+				assert.NoError(t, err)
+			})
+
+			err := currencyStore.Create(ctx, tc.input)
+			if tc.expectDuplicateError {
+				assert.True(t, mongo.IsDuplicateKeyError(err))
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCurrency_Count(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background() //nolint: forbidigo
+	cfg := config.Get()
+
+	db, err := database.NewMongoDB(ctx, cfg.MongoDB.URI, cfg.MongoDB.Database)
+	require.NoError(t, err)
+	currencyStore := store.NewCurrency(db)
+
+	testCases := []struct {
+		desc          string
+		preconditions []models.Currency
+		expected      int
+	}{
+		{
+			desc:     "positive: count currencies when collection is empty",
+			expected: 0,
+		},
+		{
+			desc: "positive: count currencies when collection has items",
+			preconditions: []models.Currency{
+				{
+					ID:     uuid.NewString(),
+					Name:   "US Dollar",
+					Symbol: "$",
+				},
+				{
+					ID:     uuid.NewString(),
+					Name:   "Euro",
+					Symbol: "€",
+				},
+			},
+			expected: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			if len(tc.preconditions) > 0 {
+				for _, currency := range tc.preconditions {
+					err = currencyStore.Create(ctx, &currency)
+					assert.NoError(t, err)
+				}
+			}
+
+			t.Cleanup(func() {
+				if len(tc.preconditions) > 0 {
+					for _, currency := range tc.preconditions {
+						_, err := currencyStore.DB.Collection("Currencies").DeleteOne(ctx, bson.M{"_id": currency.ID})
+						assert.NoError(t, err)
+					}
+				}
+			})
+
+			count, err := currencyStore.Count(ctx)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, count)
+		})
+	}
+}
+
+func TestCurrency_List(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background() //nolint: forbidigo
+	cfg := config.Get()
+
+	db, err := database.NewMongoDB(ctx, cfg.MongoDB.URI, cfg.MongoDB.Database)
+	require.NoError(t, err)
+	currencyStore := store.NewCurrency(db)
+
+	testCases := []struct {
+		desc          string
+		preconditions []models.Currency
+		expected      []models.Currency
+	}{
+		{
+			desc:     "positive: empty list when no currencies",
+			expected: []models.Currency{},
+		},
+		{
+			desc: "positive: list all currencies",
+			preconditions: []models.Currency{
+				{
+					ID:     uuid.NewString(),
+					Name:   "US Dollar",
+					Symbol: "$",
+				},
+				{
+					ID:     uuid.NewString(),
+					Name:   "Euro",
+					Symbol: "€",
+				},
+			},
+			expected: []models.Currency{
+				{
+					ID:     uuid.NewString(),
+					Name:   "US Dollar",
+					Symbol: "$",
+				},
+				{
+					ID:     uuid.NewString(),
+					Name:   "Euro",
+					Symbol: "€",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			if len(tc.preconditions) > 0 {
+				for _, currency := range tc.preconditions {
+					err = currencyStore.Create(ctx, &currency)
+					assert.NoError(t, err)
+				}
+			}
+
+			t.Cleanup(func() {
+				for _, currency := range tc.preconditions {
+					_, err := currencyStore.DB.Collection("Currencies").DeleteOne(ctx, bson.M{"_id": currency.ID})
+					assert.NoError(t, err)
+				}
+			})
+
+			currencies, err := currencyStore.List(ctx)
+			assert.NoError(t, err)
+
+			if len(tc.preconditions) == 0 {
+				assert.Empty(t, currencies)
+				return
+			}
+
+			for i, currency := range currencies {
+				assert.Equal(t, tc.preconditions[i].Name, currency.Name)
+				assert.Equal(t, tc.preconditions[i].Symbol, currency.Symbol)
+			}
+		})
+	}
+}

--- a/internal/store/currency_test.go
+++ b/internal/store/currency_test.go
@@ -25,7 +25,7 @@ func TestCurrency_Create(t *testing.T) {
 
 	currencyStore := store.NewCurrency(db)
 
-	testCases := []struct {
+	testCases := [...]struct {
 		desc                 string
 		preconditions        *models.Currency
 		input                *models.Currency
@@ -40,7 +40,6 @@ func TestCurrency_Create(t *testing.T) {
 			},
 		},
 	}
-
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
@@ -72,7 +71,7 @@ func TestCurrency_Count(t *testing.T) {
 	require.NoError(t, err)
 	currencyStore := store.NewCurrency(db)
 
-	testCases := []struct {
+	testCases := [...]struct {
 		desc          string
 		preconditions []models.Currency
 		expected      int
@@ -100,7 +99,6 @@ func TestCurrency_Count(t *testing.T) {
 			expected: 2,
 		},
 	}
-
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
@@ -139,7 +137,7 @@ func TestCurrency_List(t *testing.T) {
 	require.NoError(t, err)
 	currencyStore := store.NewCurrency(db)
 
-	testCases := []struct {
+	testCases := [...]struct {
 		desc          string
 		preconditions []models.Currency
 		expected      []models.Currency
@@ -176,7 +174,6 @@ func TestCurrency_List(t *testing.T) {
 			},
 		},
 	}
-
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {

--- a/internal/store/currency_test.go
+++ b/internal/store/currency_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
 )
 
 func TestCurrency_Create(t *testing.T) {
@@ -23,9 +22,8 @@ func TestCurrency_Create(t *testing.T) {
 
 	db, err := database.NewMongoDB(ctx, cfg.MongoDB.URI, cfg.MongoDB.Database)
 	require.NoError(t, err)
-	currencyStore := store.NewCurrency(db)
 
-	currencyID := uuid.NewString()
+	currencyStore := store.NewCurrency(db)
 
 	testCases := []struct {
 		desc                 string
@@ -40,20 +38,6 @@ func TestCurrency_Create(t *testing.T) {
 				Name:   "US Dollar",
 				Symbol: "$",
 			},
-		},
-		{
-			desc: "negative: currency not created because already exists",
-			preconditions: &models.Currency{
-				ID:     currencyID,
-				Name:   "Euro",
-				Symbol: "€",
-			},
-			input: &models.Currency{
-				ID:     currencyID,
-				Name:   "Euro",
-				Symbol: "€",
-			},
-			expectDuplicateError: true,
 		},
 	}
 
@@ -73,11 +57,7 @@ func TestCurrency_Create(t *testing.T) {
 			})
 
 			err := currencyStore.Create(ctx, tc.input)
-			if tc.expectDuplicateError {
-				assert.True(t, mongo.IsDuplicateKeyError(err))
-			} else {
-				assert.NoError(t, err)
-			}
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -107,11 +87,13 @@ func TestCurrency_Count(t *testing.T) {
 				{
 					ID:     uuid.NewString(),
 					Name:   "US Dollar",
+					Code:   "USD",
 					Symbol: "$",
 				},
 				{
 					ID:     uuid.NewString(),
 					Name:   "Euro",
+					Code:   "EUR",
 					Symbol: "€",
 				},
 			},


### PR DESCRIPTION
### What does this PR do and why?
This PR adds ability to:
1. Fetch and create currencies in store if they previously weren't created on application start.


### Additional notes
Currently we limit currencies count to 161(The number of available currencies in CurrencyBeacon API). The limitation was added to prevent uneccesary request on each application start. At that moment it's mandatory step, since we have limit for free requests to CurrencyBeacon API. Right now this limit is around 5k request.