### PR TITLE
fix(createBalanceFlow): do not create balance in db right after entering name

### DIFF
--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -45,15 +45,16 @@ func (h *handlerService) RegisterHandlers() {
 	h.flowWithFlowStepsHandlers = map[models.Flow]map[models.FlowStep]flowStepHandlerFunc{
 		// Flows with balances
 		models.StartFlow: {
-			models.CreateInitialBalanceFlowStep: h.handleCreateBalanceFlowStep,
-			models.EnterBalanceAmountFlowStep:   h.handleEnterBalanceAmountFlowStep,
-			models.EnterBalanceCurrencyFlowStep: h.handleEnterBalanceCurrencyFlowStep,
+			models.CreateInitialBalanceFlowStep: h.handleCreateInitialBalanceFlowStep,
+			// NOTE: We're using -ForUpdate methods, since the balance after first step is already created in the store.
+			models.EnterBalanceAmountFlowStep:   h.handleEnterBalanceAmountFlowStepForUpdate,
+			models.EnterBalanceCurrencyFlowStep: h.handleEnterBalanceCurrencyFlowStepForUpdate,
 		},
 		models.CreateBalanceFlow: {
 			models.CreateBalanceFlowStep:        h.handleCreateBalanceFlowStep,
-			models.EnterBalanceNameFlowStep:     h.handleEnterBalanceNameFlowStep,
-			models.EnterBalanceAmountFlowStep:   h.handleEnterBalanceAmountFlowStep,
-			models.EnterBalanceCurrencyFlowStep: h.handleEnterBalanceCurrencyFlowStep,
+			models.EnterBalanceNameFlowStep:     h.handleEnterBalanceNameFlowStepForCreate,
+			models.EnterBalanceAmountFlowStep:   h.handleEnterBalanceAmountFlowStepForCreate,
+			models.EnterBalanceCurrencyFlowStep: h.handleEnterBalanceCurrencyFlowStepForCreate,
 		},
 		models.GetBalanceFlow: {
 			models.GetBalanceFlowStep:    h.handleGetBalanceFlowStep,
@@ -63,8 +64,8 @@ func (h *handlerService) RegisterHandlers() {
 			models.UpdateBalanceFlowStep:        h.handleUpdateBalanceFlowStep,
 			models.ChooseBalanceFlowStep:        h.handleChooseBalanceFlowStepForUpdate,
 			models.EnterBalanceNameFlowStep:     h.handleEnterBalanceNameFlowStepForUpdate,
-			models.EnterBalanceAmountFlowStep:   h.handleEnterBalanceAmountFlowStep,
-			models.EnterBalanceCurrencyFlowStep: h.handleEnterBalanceCurrencyFlowStep,
+			models.EnterBalanceAmountFlowStep:   h.handleEnterBalanceAmountFlowStepForUpdate,
+			models.EnterBalanceCurrencyFlowStep: h.handleEnterBalanceCurrencyFlowStepForUpdate,
 		},
 		models.DeleteBalanceFlow: {
 			models.DeleteBalanceFlowStep:          h.handleDeleteBalanceFlowStep,

--- a/internal/service/services.go
+++ b/internal/service/services.go
@@ -204,6 +204,7 @@ const (
 	// Balance related keys
 	balanceIDMetadataKey              = "balance_id"
 	balanceNameMetadataKey            = "balance_name"
+	balanceAmountMetadataKey          = "balance_amount"
 	balanceFromMetadataKey            = "balance_from"
 	balanceToMetadataKey              = "balance_to"
 	currentBalanceNameMetadataKey     = "current_balance_name"


### PR DESCRIPTION
### What does this PR to and why?
The initial issue was described in #76, but the root cause was deeper. We were using shared step handlers for both the Create and Update Balance flows, which led to this problem. During the review, I decided to create separate step handlers for each flow to resolve the issue.




Resolve #76 