### PR TITLE
feat(operationThroughOneTimeInput): add step with data confirmation

### DIFF
--- a/internal/models/state.go
+++ b/internal/models/state.go
@@ -348,4 +348,6 @@ const (
 	EnterOperationDateFlowStep FlowStep = "enter_operation_date"
 	// CreateOperationsThroughOneTimeInputFlowStep represents the step for creating operations through one-time input
 	CreateOperationsThroughOneTimeInputFlowStep FlowStep = "create_operations_through_one_time_input"
+	// ConfirmOperationDetailsFlowStep represents the step for confirming operation details
+	ConfirmOperationDetailsFlowStep FlowStep = "confirm_operation_details"
 )

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -129,6 +129,7 @@ func (h *handlerService) RegisterHandlers() {
 		models.CreateOperationsThroughOneTimeInputFlow: {
 			models.CreateOperationsThroughOneTimeInputFlowStep: h.handleCreateOperationsThroughOneTimeInputFlowStep,
 			models.ChooseBalanceFlowStep:                       h.handleChooseBalanceFlowStepForOneTimeInputOperationCreate,
+			models.ConfirmOperationDetailsFlowStep:             h.handleConfirmOperationDetailsFlowStepForOneTimeInputOperationCreate,
 		},
 	}
 }


### PR DESCRIPTION
### What does this PR do and why?

Added confirmation step after extracting operation data from the prompt output.