### PR TITLE
fix: do not return error if user not found during state handling

### DIFF
--- a/internal/service/event.go
+++ b/internal/service/event.go
@@ -118,7 +118,7 @@ func (e eventService) handlePanic(ctx context.Context, msg Message, r any) {
 }
 
 func getEventFromMsg(user *models.User, msg Message) models.Event {
-	aiParserEnabled := user.Settings != nil && user.Settings.AIParserEnabled
+	aiParserEnabled := user != nil && user.Settings != nil && user.Settings.AIParserEnabled
 	inputIsNotACommand := !strings.Contains(strings.Join(models.AvailableCommands, " "), msg.GetText())
 
 	if aiParserEnabled && inputIsNotACommand {

--- a/internal/service/state.go
+++ b/internal/service/state.go
@@ -53,10 +53,6 @@ func (s stateService) HandleState(ctx context.Context, message Message) (*Handle
 		logger.Error().Err(err).Msg("get user from store")
 		return nil, fmt.Errorf("get user from store: %w", err)
 	}
-	if user == nil {
-		logger.Error().Msg("user not found")
-		return nil, fmt.Errorf("user not found")
-	}
 
 	event := getEventFromMsg(user, message)
 	logger.Debug().Any("event", event).Msg("got event based on bot message")


### PR DESCRIPTION
### What does this PR do and why?
Previously, a user existence check was introduced while implementing the AI parser with user settings. However, it was overlooked that a user might not exist in the database when they start the bot for the first time.

To address this, instead of strictly checking for user existence, I improved the logic by refining the aiParserEnabled flag check, ensuring it only applies when a non-nil user is present.